### PR TITLE
Update README to document .to_s method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ https://rubygems.org/gems/ruby_xid
 
 ```
 guid = Xid.new
-guid.string
+guid.to_s
 
 # output:
 "bnl5su800jo0po2ac17g"


### PR DESCRIPTION
README was misleading. The `.string` method is defined as private in the lib. Document using `.to_s` to get the Xid string representation.